### PR TITLE
Convert.py für Kitti Dataset

### DIFF
--- a/data/kitti/README.md
+++ b/data/kitti/README.md
@@ -21,21 +21,17 @@ In the end your directory structure should look like the following
 
   
     ├── images/
-    │   └── test/
-    │         └── xxx.txt
     │    └── train/
-    │         └── yyy.txt
-    │     └── val/
-    │         └── zzz.txt
-    ├── labels/
-    │     └── test/
-    │         └── xxx.png
-    │     └── train/
     │         └── yyy.png
     │     └── val/
     │         └── zzz.png
-    ├── .gitignore
-    ├── classes.json
+    ├── labels/
+    │     └── train/
+    │         └── yyy.txt
+    │     └── val/
+    │         └── zzz.txt
+    ├── config.yaml
+    ├── convert.py
     ├── main.ipynb
     └── README.md
 
@@ -59,7 +55,7 @@ More info/reference here: https://www.kaggle.com/datasets/shreydan/kitti-dataset
 
 **Data structure:** 
 Each png-file in images has a corresponding YOLO format txt file in labels
-(images/test/000000.png for labels/test/000000.txt)
+(images/train/000000.png for labels/train/000000.txt)
 
 
 **Classes for objects:**
@@ -72,5 +68,3 @@ Each png-file in images has a corresponding YOLO format txt file in labels
  'Misc': 5,\
  'Tram': 6,\
  'Person_sitting': 7
-
-

--- a/data/kitti/README.md
+++ b/data/kitti/README.md
@@ -59,7 +59,7 @@ More info/reference here: https://www.kaggle.com/datasets/shreydan/kitti-dataset
 
 **Data structure:** 
 Each png-file in images has a corresponding YOLO format txt file in kitti-dataset-yolo-format/labels
-(images/test/000000.png <-> annotations/labels/000000.txt)
+(images/test/000000.png <-> labels/test/000000.txt)
 
 
 **Classes for objects:**

--- a/data/kitti/README.md
+++ b/data/kitti/README.md
@@ -58,8 +58,8 @@ More info/reference here: https://www.kaggle.com/datasets/shreydan/kitti-dataset
 
 
 **Data structure:** 
-Each png-file in images has a corresponding YOLO format txt file in kitti-dataset-yolo-format/labels
-(images/test/000000.png <-> labels/test/000000.txt)
+Each png-file in images has a corresponding YOLO format txt file in labels
+(images/test/000000.png for labels/test/000000.txt)
 
 
 **Classes for objects:**

--- a/data/kitti/README.md
+++ b/data/kitti/README.md
@@ -9,10 +9,11 @@ Kitti object detection dataset with 2d bounding boxes
 1. Download the "data_object_image2" subdirectory from the 'kitti dataset' https://www.kaggle.com/datasets/klemenko/kitti-dataset?select=data_object_image_2 
 !The download should only be 11+Gb, we do not need to download the entire dataset (24GB)
 2. Download 'kitti-yolo-labels' from https://www.kaggle.com/datasets/shreydan/kitti-dataset-yolo-format 
-3. Extract the folders "data_object_image2/training/image_2" and "kitti-yolo-labels/labels" into this directiory
-4. Rename the folder "data_object_image2/training/image_2" to "images" 
-5. Rename the "kitti-yolo-labels/labels" folder to "annotations"
+3. Extract the folders `data_object_image2/training/image_2` and `kitti-yolo-labels/labels` into this directiory
+4. Rename the folder `data_object_image2/training/image_2` to `images`
+5. Rename the `kitti-yolo-labels/labels` folder to `annotations`
 6. Run convert.py to generate the train/val/test split (70%/15%/15%)
+7. Feel free to delete the empty `annotations` folder now
 
 
 

--- a/data/kitti/README.md
+++ b/data/kitti/README.md
@@ -12,17 +12,28 @@ Kitti object detection dataset with 2d bounding boxes
 3. Extract the folders "data_object_image2/training/image_2" and "kitti-yolo-labels/labels" into this directiory
 4. Rename the folder "data_object_image2/training/image_2" to "images" 
 5. Rename the "kitti-yolo-labels/labels" folder to "annotations"
-6. 
+6. Run convert.py to generate the train/val/test split (70%/15%/15%)
 
 
 
 
 In the end your directory structure should look like the following
 
-    ├── annotations/
-    │   └── 000000.txt
+  
     ├── images/
-    │   └── 000000.png
+    │   └── test/
+    │         └── xxx.txt
+    │    └── train/
+    │         └── yyy.txt
+    │     └── val/
+    │         └── zzz.txt
+    ├── labels/
+    │     └── test/
+    │         └── xxx.png
+    │     └── train/
+    │         └── yyy.png
+    │     └── val/
+    │         └── zzz.png
     ├── .gitignore
     ├── classes.json
     ├── main.ipynb
@@ -47,8 +58,8 @@ More info/reference here: https://www.kaggle.com/datasets/shreydan/kitti-dataset
 
 
 **Data structure:** 
-Each png-file in data_object_image_2/training/image_2 has a corresponding YOLO format txt file in kitti-dataset-yolo-format/labels
-(000000.png <-> 000000.txt)
+Each png-file in images has a corresponding YOLO format txt file in kitti-dataset-yolo-format/labels
+(images/test/000000.png <-> annotations/labels/000000.txt)
 
 
 **Classes for objects:**

--- a/data/kitti/convert.py
+++ b/data/kitti/convert.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+import random
+import xml.etree.ElementTree as ET
+
+
+
+
+
+
+src_dir_img = 'images'
+src_dir_anno = 'annotations'
+dest_dir_train = 'train'
+dest_dir_val = 'val'
+dest_dir_test = 'test'
+
+def randomly_assign_files(train_ratio=0.7, val_ratio = 0.15, test_ratio = 0.15):
+    image_files = [f for f in os.listdir(src_dir_img) if f.endswith('.png')]
+    annotation_files = [f for f in os.listdir(src_dir_anno) if f.endswith('.txt')]
+    image_files.sort()
+    annotation_files.sort()
+    
+    #create new subfolders for images
+    os.makedirs(src_dir_img + '/' + dest_dir_train, exist_ok=True)
+    os.makedirs(src_dir_img + '/' + dest_dir_val, exist_ok=True)
+    os.makedirs(src_dir_img + '/' + dest_dir_test, exist_ok=True)
+
+    #new subfolders for annotations
+    os.makedirs(src_dir_anno + '/' + dest_dir_train, exist_ok=True)
+    os.makedirs(src_dir_anno + '/' + dest_dir_val, exist_ok=True)
+    os.makedirs(src_dir_anno + '/' + dest_dir_test, exist_ok=True)
+
+    for image_file, annotation_file in zip(image_files, annotation_files):
+        rand_num = random.random()
+        if rand_num < train_ratio: #70% train
+            dest_dir = dest_dir_train
+        elif rand_num < train_ratio + val_ratio: #15% val
+            dest_dir = dest_dir_val
+        else: #15% test
+            dest_dir = dest_dir_test
+
+        img_start_path = src_dir_img + '/' + image_file
+        img_end_path = src_dir_img + '/' + dest_dir + '/' + image_file
+        anno_start_path = src_dir_anno + '/' + annotation_file
+        anno_end_path = src_dir_anno + '/' + dest_dir + '/' + annotation_file
+        
+        
+        #move pictures and annotations
+        shutil.move(img_start_path, img_end_path)
+        shutil.move(anno_start_path, anno_end_path)
+
+
+
+
+
+
+if __name__ == "__main__":
+    randomly_assign_files() #split the images into 70% train 15% val 15% test

--- a/data/kitti/convert.py
+++ b/data/kitti/convert.py
@@ -11,7 +11,7 @@ dest_dir_train = 'train'
 dest_dir_val = 'val'
 dest_dir_test = 'test'
 
-def randomly_assign_files(train_ratio=0.7, val_ratio = 0.15, test_ratio = 0.15):
+def randomly_assign_files(train_ratio=0.8):
     image_files = [f for f in os.listdir(src_dir_img) if f.endswith('.png')]
     annotation_files = [f for f in os.listdir(src_dir_anno) if f.endswith('.txt')]
     image_files.sort()
@@ -20,27 +20,27 @@ def randomly_assign_files(train_ratio=0.7, val_ratio = 0.15, test_ratio = 0.15):
     #create new subfolders for images
     os.makedirs(src_dir_img + '/' + dest_dir_train, exist_ok=True)
     os.makedirs(src_dir_img + '/' + dest_dir_val, exist_ok=True)
-    os.makedirs(src_dir_img + '/' + dest_dir_test, exist_ok=True)
 
-    #new subfolders for annotations
-    os.makedirs(src_dir_anno + '/' + dest_dir_train, exist_ok=True)
-    os.makedirs(src_dir_anno + '/' + dest_dir_val, exist_ok=True)
-    os.makedirs(src_dir_anno + '/' + dest_dir_test, exist_ok=True)
+
+    #new subfolders for labels
+    os.makedirs(dest_dir_anno, exist_ok=True)
+    os.makedirs(dest_dir_anno + '/' + dest_dir_train, exist_ok=True)
+    os.makedirs(dest_dir_anno + '/' + dest_dir_val, exist_ok=True)
+
 
     for image_file, annotation_file in zip(image_files, annotation_files):
         rand_num = random.random()
         if rand_num < train_ratio: #70% train
             dest_dir = dest_dir_train
-        elif rand_num < train_ratio + val_ratio: #15% val
-            dest_dir = dest_dir_val
         else: #15% test
-            dest_dir = dest_dir_test
+            dest_dir = dest_dir_val
 
         img_start_path = src_dir_img + '/' + image_file
         img_end_path = src_dir_img + '/' + dest_dir + '/' + image_file
         anno_start_path = src_dir_anno + '/' + annotation_file
         anno_end_path = dest_dir_anno + '/' + dest_dir + '/' + annotation_file
-        
+        print(f"Moving image from {img_start_path} to {img_end_path}")
+        print(f"Moving annotation from {anno_start_path} to {anno_end_path}")
         
         #move pictures and annotations
         shutil.move(img_start_path, img_end_path)

--- a/data/kitti/convert.py
+++ b/data/kitti/convert.py
@@ -1,15 +1,12 @@
 import os
 import shutil
 import random
-import xml.etree.ElementTree as ET
-
-
-
-
 
 
 src_dir_img = 'images'
 src_dir_anno = 'annotations'
+
+dest_dir_anno = 'labels'
 dest_dir_train = 'train'
 dest_dir_val = 'val'
 dest_dir_test = 'test'
@@ -42,7 +39,7 @@ def randomly_assign_files(train_ratio=0.7, val_ratio = 0.15, test_ratio = 0.15):
         img_start_path = src_dir_img + '/' + image_file
         img_end_path = src_dir_img + '/' + dest_dir + '/' + image_file
         anno_start_path = src_dir_anno + '/' + annotation_file
-        anno_end_path = src_dir_anno + '/' + dest_dir + '/' + annotation_file
+        anno_end_path = dest_dir_anno + '/' + dest_dir + '/' + annotation_file
         
         
         #move pictures and annotations


### PR DESCRIPTION
convert.py für kittidataset hinzugefügt und die README entsprechend aktualisiert.

 Wollen wir die Daten in train/val/test oder train/val unterteilen? Momentan teilt convert.py in 70% Train, 15% Val, 15% Test.